### PR TITLE
Remove arbitrary password length limit.

### DIFF
--- a/views/helpers.php
+++ b/views/helpers.php
@@ -865,10 +865,10 @@ function form_add_account_2 ($account_new, $action, $values, $disabled=array())
     $tag .= '<table class="table table-bordered">'."\n";
 
     $tag .= '<tr class="warning"><td>'._("Password").'</td>'."\n";
-    $tag .= '<td><input autocomplete="off" type="password" class="form-control" name="password1" value="" size="50" maxlength="50" /></td></tr>'."\n";
+    $tag .= '<td><input autocomplete="off" type="password" class="form-control" name="password1" value="" size="50" /></td></tr>'."\n";
 
     $tag .= '<tr class="warning"><td>'._("Confirm Password").'</td>'."\n";
-    $tag .= '<td><input autocomplete="off" type="password" class="form-control" name="password2" value="" size="50" maxlength="50" /></td></tr>'."\n";
+    $tag .= '<td><input autocomplete="off" type="password" class="form-control" name="password2" value="" size="50" /></td></tr>'."\n";
 
     $tag .= '<tr class="warning"><td>'._("Name").' *</td>'."\n";
     $tag .= '<td><input type="text" class="form-control" name="givenname" value="'.stripslashes($givenName).'" size="15" maxlength="50" /></td></tr>'."\n";


### PR DESCRIPTION
The password length is currently limited to 50 characters but longer passwords are possible.  If passwords longer than a certain length shouldn't be specified this should be checked and an error issued once the data is submitted otherwise what happens is the password is truncated but the user is not aware until they go to use the password and it doesn't work.